### PR TITLE
RC-2968 Add extended response

### DIFF
--- a/src/structs/2captcha.ts
+++ b/src/structs/2captcha.ts
@@ -338,7 +338,9 @@ export class Solver {
         try {
             data = JSON.parse(result)
             if (data.status == 1) {
-                return { data: data.request, id: id }
+                let dataJSON = { ...data, data: data.request, id: id}
+                delete dataJSON.request
+                return dataJSON
             }
         } catch {
             throw new APIError(result)

--- a/src/structs/2captcha.ts
+++ b/src/structs/2captcha.ts
@@ -347,7 +347,6 @@ export class Solver {
         }
         switch (data.request) {
             case "CAPCHA_NOT_READY": 
-                // console.log('CAPCHA_NOT_READY')
                 return this.pollResponse(id);
             default: {
                 throw new APIError(data.request)


### PR DESCRIPTION
### What's changed: 
- The extended response is returned.
  Example -  old response for hCapthca:
  ```js
    {
      data: 'P1_eyJ0ezlOFCA...',
      id: '868759524121'
    }
   ```
  Example -  new response for hCapthca:
    ```js
    {
      status: 1,
      useragent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
      respKey: 'E0_eyJ0eXAiOiJKV1QiLCJhb...s',
      data: 'P1_eyJ0eXAi2MTMMvyqJf3WQ...',
      id: '868759524121'
    }
```
